### PR TITLE
feat: Don't require learners to install 'ctr'

### DIFF
--- a/.wr.toml
+++ b/.wr.toml
@@ -1,2 +1,3 @@
 [[verification]]
-command = "ctr"
+command = "cargo"
+args = ["run", "--package", "ctr", "--bin", "ctr"]

--- a/book/src/00_intro/00_welcome.md
+++ b/book/src/00_intro/00_welcome.md
@@ -76,14 +76,6 @@ Each exercise is structured as a Rust package.
 The package contains the exercise itself, instructions on what to do (in `src/lib.rs`), and a mechanism to
 automatically verify your solution.
 
-You also need to install `ctr` (**C**heck **T**est **R**esults), a little tool that will be invoked
-to verify the outcomes of your tests:
-
-```bash
-# Install `ctr` from the top-level folder of the repository
-cargo install --path ctr
-```
-
 ### `wr`, the workshop runner
 
 To verify your solutions, we've also provided a tool to guide you through the course: the `wr` CLI, short for "workshop runner".

--- a/exercises/00_intro/00_welcome/src/lib.rs
+++ b/exercises/00_intro/00_welcome/src/lib.rs
@@ -2,9 +2,14 @@
 mod tests {
     #[test]
     fn ctr_is_installed_and_on_path() {
-        std::process::Command::new("ctr")
+        std::process::Command::new("cargo")
+            .arg("run")
+            .arg("--package")
+            .arg("ctr")
+            .arg("--bin")
+            .arg("ctr")
             .output()
-            .expect("Failed to invoke `ctr`");
+            .expect("Failed to invoke `ctr` through `cargo`");
     }
 
     #[test]


### PR DESCRIPTION
We had various issues with binary name conflicts—e.g. folks having another binary named `ctr` in their path, shadowing ours, thus leading to puzzling errors when invoked.
We can sidestep the issue entirely by invoking `ctr` via `cargo`.