### PR TITLE
Fix HTTP test outcome

### DIFF
--- a/exercises/07_http_mocking/02_match/src/lib.rs
+++ b/exercises/07_http_mocking/02_match/src/lib.rs
@@ -78,7 +78,8 @@ mod tests {
 
         let outcome = client
             .post(&server.uri())
-            .header("Content-Length", length)
+            .header("Content-Length", length - 1)
+            .header("Content-Type", "application/json")
             .body(body)
             .send()
             .await


### PR DESCRIPTION
Hi there! Thanks for providing great Rust workshops, including this one.

I found a small issue in the test outcome and fixed it. In the test `errors_on_invalid_content_length`:

- `Content-Length` should not match the length of the body.
- `Content-Type` should be included, since it's not part of the test criteria.

This change should also be applied to the `solutions` branch.