### PR TITLE
typo: ctr -> wr

### DIFF
--- a/book/src/01_better_assertions/00_intro.md
+++ b/book/src/01_better_assertions/00_intro.md
@@ -5,7 +5,7 @@ Let's discuss how automated verification works in this course.
 
 This is a testing workshop, therefore we need to check that the _tests_ you write behave as expected. It's a bit meta!\
 It's not enough to know that a test failed, we also need to know _why_ it failed and what message it produced.
-We do this by using `ctr`, the custom tool you just installed. It runs the tests in each exercise and compares
+We do this by using `wr`, the workshop runner tool you just installed. It runs the tests in each exercise and compares
 the outcome with a set of expectations.
 
 You can find those expectations in


### PR DESCRIPTION
Spotted what seems to be a typo in the intro to section 1.

I think the newly installed tool refers to the workshop runner (presumably the tool had a name change at some point but this reference to it wasn't updated).